### PR TITLE
Implement scheduled chat messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "express-rate-limit": "^6.10.0",
         "helmet": "^7.1.0",
         "node-fetch": "^2.7.0",
-        "winston": "^3.10.0"
+        "winston": "^3.10.0",
+        "ws": "^8.13.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -5310,6 +5311,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "compression": "^1.7.4",
     "express-rate-limit": "^6.10.0",
     "node-fetch": "^2.7.0",
-    "winston": "^3.10.0"
+    "winston": "^3.10.0",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1",
@@ -41,3 +42,4 @@
     "url": "https://github.com/tu-usuario/pnptv-live"
   }
 }
+


### PR DESCRIPTION
## Summary
- add ws dependency
- implement WebSocket server for notifications
- create utilities to broadcast chat messages
- add endpoints to schedule and send messages

## Testing
- `npm install --include=dev`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68636f9edb9c8332a2c80089edcf8832

## Summary by Sourcery

Implement scheduled and real-time chat notifications with WebSocket support and API endpoints for scheduling, sending, and listing messages for admins and performers.

New Features:
- Add WebSocket server and client management to broadcast chat messages to connected clients.
- Implement message scheduling functionality for one-time and recurring chat messages.
- Expose admin and performer REST endpoints to schedule, send, and list chat messages.

Enhancements:
- Add ws dependency for WebSocket support in package.json.